### PR TITLE
fixed broken link to requestbin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2476,7 +2476,7 @@ A Subset for __Architecture and Infrastructure__
   * [CodePen](http://codepen.io/) / [CodeSandbox](https://codesandbox.io/)
     * CDN for npm - [unpkg](https://unpkg.com/)
   * [RunKit](https://runkit.com)
-  * [RequestBin](http://requestb.in/)
+  * [RequestBin](https://requestbin.com/)
   * [jsPerf](https://jsperf.com/)
   * [CSS in JS Playground](https://css-in-js-playground.com/)
   * [GraphQL Playground](https://github.com/graphcool/graphql-playground), [Apollo Launchpad](https://launchpad.graphql.com)


### PR DESCRIPTION
Original hosted version of requestbin was taken down in 2018. Have updated link to alternative service.