### PR TITLE
add moleculer to microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1668,7 +1668,7 @@ A Subset for __Architecture and Infrastructure__
       * Configuration - [Hapi](https://hapijs.com/)
       * Realtime - [Feathers](https://feathersjs.com/)
   * Microservices
-    * [Micro](https://www.npmjs.com/package/micro) / [Seneca](http://senecajs.org/) / [StdLib](https://stdlib.com/)
+    * [Micro](https://www.npmjs.com/package/micro) / [Moleculer](https://moleculer.services/) / [Seneca](http://senecajs.org/) / [StdLib](https://stdlib.com/)
   * Serverless
     * [Serverless Framework](https://github.com/serverless/serverless)
     * [IronFunctions](https://github.com/iron-io/functions)


### PR DESCRIPTION
Cote and Moleculer are not listed currently. Here, I've provided a quick viewpoint on  the tradeoffs.

Moleculer is new, and much faster than Seneca. Moleculer serves as a full framework and therefore has many more features compared to micro.

Cote is faster than Moleculer according to Moleculer's benchmark. Cote is older and therefore more established. 

Micro is by far the most popular: https://www.npmtrends.com/cote-vs-seneca-vs-micro-vs-nanoservices-vs-moleculer.

So we have these specializations:
* micro: Very Popular, Performant, Dead-Simple
* Molecular: New, Fast, Feature-Rich, Modular Library of Plugins
* Cote: Older, More Established, Faster than Molecular
* Seneca: Older, More Established, Much slower than Molecular

I have not added Cote for now, but it may be considered as a replacement for Seneca based on the tradeoffs between the two which I am not familiar with. Or perhaps Moleculer can replace Seneca; I'm just not confident enough to personally say it can completely replace Seneca.